### PR TITLE
Build debug and release configurations on AppVeyor

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Codecov" version="1.0.1" />
+  <package id="Codecov" version="1.1.0" />
   <package id="Microsoft.DiaSymReader.Pdb2Pdb" version="1.1.0-beta1-62624-01" />
   <package id="OpenCover" version="4.6.519" />
   <package id="ReportGenerator" version="2.3.5.0" targetFramework="net452" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,10 @@ test_script:
     if ($env:Configuration -eq 'Debug') {
       .\opencover-report.ps1 -Debug -NoBuild -NoReport -AppVeyor
       if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
-      ..\packages\Codecov.1.0.1\tools\codecov.exe -f '..\build\OpenCover.Reports\OpenCover.DocumentationAnalyzers.xml'
+      $packageConfig = [xml](Get-Content ..\.nuget\packages.config)
+      $codecov_version = $packageConfig.SelectSingleNode('/packages/package[@id="Codecov"]').version
+      $codecov = "..\packages\Codecov.$codecov_version\tools\codecov.exe"
+      &$codecov -f '..\build\OpenCover.Reports\OpenCover.DocumentationAnalyzers.xml'
     } else {
       .\opencover-report.ps1 -NoBuild -NoReport -AppVeyor
       if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,9 @@ test_script:
 cache:
   - packages -> **\packages.config
   - C:\Users\appveyor\.nuget\packages -> appveyor.yml
+
+# 'Release' is hard-coded to ensure VSIX and NuGet artifacts are only published for release configuration builds
 artifacts:
-- path: 'DocumentationAnalyzers\**\*.vsix'
-- path: 'DocumentationAnalyzers\**\*.nupkg'
+- path: 'DocumentationAnalyzers\DocumentationAnalyzers.Vsix\bin\Release\net452\*.vsix'
+- path: 'DocumentationAnalyzers\DocumentationAnalyzers.CodeFixes\bin\Release\*.nupkg'
 - path: 'DocumentationAnalyzers.Status.json'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,9 @@ version: '{build}'
 image: Visual Studio 2017
 init:
 - git config --global core.autocrlf true
+configuration:
+- Debug
+- Release
 before_build:
 - nuget restore
 build:
@@ -9,10 +12,17 @@ build:
   verbosity: minimal
 test_script:
 - cd build
-- ps: .\opencover-report.ps1 -Debug -NoBuild -NoReport -AppVeyor
+- ps: |
+    if ($env:Configuration -eq 'Debug') {
+      .\opencover-report.ps1 -Debug -NoBuild -NoReport -AppVeyor
+      if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+      ..\packages\Codecov.1.0.1\tools\codecov.exe -f '..\build\OpenCover.Reports\OpenCover.DocumentationAnalyzers.xml'
+    } else {
+      .\opencover-report.ps1 -NoBuild -NoReport -AppVeyor
+      if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+    }
 - cd ..
-- .\packages\Codecov.1.0.1\tools\codecov.exe -f ".\build\OpenCover.Reports\OpenCover.DocumentationAnalyzers.xml"
-- .\DocumentationAnalyzers\DocumentationAnalyzers.Status.Generator\bin\Debug\net46\DocumentationAnalyzers.Status.Generator.exe .\DocumentationAnalyzers.sln > DocumentationAnalyzers.Status.json
+- .\DocumentationAnalyzers\DocumentationAnalyzers.Status.Generator\bin\%Configuration%\net46\DocumentationAnalyzers.Status.Generator.exe .\DocumentationAnalyzers.sln > DocumentationAnalyzers.Status.json
 cache:
   - packages -> **\packages.config
   - C:\Users\appveyor\.nuget\packages -> appveyor.yml

--- a/docs/index.html
+++ b/docs/index.html
@@ -173,7 +173,7 @@
     </script>
 
     <script type="text/javascript">
-        $.getJSON("https://ci.appveyor.com/api/projects/sharwell/Documentationanalyzers/artifacts/DocumentationAnalyzers.Status.json?branch=master&pr=false&stream=true", function (data) {
+        $.getJSON("https://ci.appveyor.com/api/projects/sharwell/Documentationanalyzers/artifacts/DocumentationAnalyzers.Status.json?branch=master&pr=false&stream=true&job=Configuration:%20Release", function (data) {
             $("#renderedDiagnostics").html($.templates($("#diagnostics").html()).render(data));
             $("#renderedCommitInfo").html($.templates($("#commitInfo").html()).render(data.git));
         });


### PR DESCRIPTION
Generally the two builds overlap. The primary differences between them are:

* Only the Debug configuration is used for code coverage reporting to codecov.io
* Only the Release configuration is used for deploying artifacts to NuGet
