### PR TITLE
Lock the 'build' version component

### DIFF
--- a/DocumentationAnalyzers/version.json
+++ b/DocumentationAnalyzers/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0-beta.{height}",
+  "version": "1.0.0-beta.{height}",
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
This change modifies the package versioning to make the git height part of the package prerelease designator but not part of the primary package version.