### PR TITLE
Avoid building tags

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ configuration:
 - Release
 before_build:
 - nuget restore
+skip_tags: true
 build:
   project: DocumentationAnalyzers.sln
   verbosity: minimal


### PR DESCRIPTION
Tags are only created after builds are published, so there is no need to build them again.