### PR TITLE
Use the same release notes tag for implementation and metadata packages

### DIFF
--- a/DocumentationAnalyzers/DocumentationAnalyzers.CodeFixes/DocumentationAnalyzers.CodeFixes.csproj
+++ b/DocumentationAnalyzers/DocumentationAnalyzers.CodeFixes/DocumentationAnalyzers.CodeFixes.csproj
@@ -72,7 +72,7 @@
       <ImplementationNuspecVersion Condition="'$(PrereleaseVersion)' != ''">$(NuspecUnstableVersion)</ImplementationNuspecVersion>
       <ImplementationNuspecVersion Condition="'$(PrereleaseVersion)' == ''">$(NuspecStableVersion)</ImplementationNuspecVersion>
 
-      <NuspecProperties>id=$(NuspecId);configuration=$(Configuration);GitCommitIdShort=$(GitCommitIdShort);version=$(NuspecVersion);implId=$(ImplementationNuspecId);implVersion=$(ImplementationNuspecVersion)</NuspecProperties>
+      <NuspecProperties>id=$(NuspecId);configuration=$(Configuration);GitCommitIdShort=$(GitCommitIdShort);version=$(NuspecVersion);tag=$(NuspecStableVersion);implId=$(ImplementationNuspecId);implVersion=$(ImplementationNuspecVersion)</NuspecProperties>
     </PropertyGroup>
   </Target>
 

--- a/DocumentationAnalyzers/DocumentationAnalyzers.CodeFixes/DocumentationAnalyzers.Metadata.nuspec
+++ b/DocumentationAnalyzers/DocumentationAnalyzers.CodeFixes/DocumentationAnalyzers.Metadata.nuspec
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/DotNetAnalyzers/DocumentationAnalyzers</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>An implementation of .NET documentation rules using Roslyn analyzers and code fixes</description>
-    <releaseNotes>https://github.com/DotNetAnalyzers/DocumentationAnalyzers/releases/$version$</releaseNotes>
+    <releaseNotes>https://github.com/DotNetAnalyzers/DocumentationAnalyzers/releases/$tag$</releaseNotes>
     <copyright>Copyright 2018 Tunnel Vision Laboratories, LLC</copyright>
     <tags>Documentation DotNetAnalyzers Roslyn Diagnostic Analyzer</tags>
     <developmentDependency>true</developmentDependency>

--- a/DocumentationAnalyzers/DocumentationAnalyzers.CodeFixes/DocumentationAnalyzers.nuspec
+++ b/DocumentationAnalyzers/DocumentationAnalyzers.CodeFixes/DocumentationAnalyzers.nuspec
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/DotNetAnalyzers/DocumentationAnalyzers</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>An implementation of .NET documentation rules using Roslyn analyzers and code fixes</description>
-    <releaseNotes>https://github.com/DotNetAnalyzers/DocumentationAnalyzers/releases/$version$</releaseNotes>
+    <releaseNotes>https://github.com/DotNetAnalyzers/DocumentationAnalyzers/releases/$tag$</releaseNotes>
     <copyright>Copyright 2018 Tunnel Vision Laboratories, LLC</copyright>
     <tags>Documentation DotNetAnalyzers Roslyn Diagnostic Analyzer</tags>
     <developmentDependency>true</developmentDependency>


### PR DESCRIPTION
In the initial (1.0.0-beta.18) release, the [DotNetAnalyzers.DocumentationAnalyzers](https://www.nuget.org/packages/DotNetAnalyzers.DocumentationAnalyzers/1.0.0-beta.18) package linked to the correct release notes, but the [DotNetAnalyzers.DocumentationAnalyzers.Unstable](https://www.nuget.org/packages/DotNetAnalyzers.DocumentationAnalyzers.Unstable/1.0.0.18) package did not. Following this change, the same release notes link is used for both packages.