### PR TITLE
[WIP] Initial implementation of inheritdoc support

### DIFF
--- a/DocumentationAnalyzers/DocumentationAnalyzers.CodeFixes/PortabilityRules/DOC205CodeFixProvider.cs
+++ b/DocumentationAnalyzers/DocumentationAnalyzers.CodeFixes/PortabilityRules/DOC205CodeFixProvider.cs
@@ -57,11 +57,15 @@ namespace DocumentationAnalyzers.PortabilityRules
             var candidateSymbol = InheritdocHelper.GetCandidateSymbol(documentedSymbol);
             var candidateDocumentation = candidateSymbol.GetDocumentationCommentXml(expandIncludes: false, cancellationToken: cancellationToken);
 
-            var xmlDocumentation = XElement.Parse(candidateDocumentation);
             var newLineText = Environment.NewLine;
 
             var content = new List<XmlNodeSyntax>();
-            content.AddRange(xmlDocumentation.Elements().Select(element => XmlSyntaxFactory.Node(newLineText, element)));
+            if (!string.IsNullOrEmpty(candidateDocumentation))
+            {
+                var xmlDocumentation = XElement.Parse(candidateDocumentation);
+                content.AddRange(xmlDocumentation.Elements().Select(element => XmlSyntaxFactory.Node(newLineText, element)));
+                content.Add(XmlSyntaxFactory.NewLine(newLineText));
+            }
 
             var newStartToken = SyntaxFactory.Identifier(oldStartToken.LeadingTrivia, XmlCommentHelper.AutoinheritdocXmlTag, oldStartToken.TrailingTrivia);
             var newXmlNode = xmlNode.ReplaceToken(oldStartToken, newStartToken);
@@ -73,7 +77,6 @@ namespace DocumentationAnalyzers.PortabilityRules
                 newXmlNode = newXmlNode.ReplaceToken(oldEndToken, newEndToken);
             }
 
-            content.Add(XmlSyntaxFactory.NewLine(newLineText));
             content.Add(newXmlNode);
 
             return document.WithSyntaxRoot(root.ReplaceNode(xmlNode, content));

--- a/DocumentationAnalyzers/DocumentationAnalyzers.CodeFixes/PortabilityRules/DOC205CodeFixProvider.cs
+++ b/DocumentationAnalyzers/DocumentationAnalyzers.CodeFixes/PortabilityRules/DOC205CodeFixProvider.cs
@@ -1,0 +1,155 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT license. See LICENSE in the project root for license information.
+
+namespace DocumentationAnalyzers.PortabilityRules
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Composition;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Xml.Linq;
+    using DocumentationAnalyzers.Helpers;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeActions;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(DOC205CodeFixProvider))]
+    [Shared]
+    internal class DOC205CodeFixProvider : CodeFixProvider
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds { get; }
+            = ImmutableArray.Create(DOC205InheritDocumentation.DiagnosticId);
+
+        public override FixAllProvider GetFixAllProvider()
+            => CustomFixAllProviders.BatchFixer;
+
+        public override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                Debug.Assert(FixableDiagnosticIds.Contains(diagnostic.Id), "Assertion failed: FixableDiagnosticIds.Contains(diagnostic.Id)");
+
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        PortabilityResources.DOC205CodeFix,
+                        token => GetTransformedDocumentAsync(context.Document, diagnostic, token),
+                        nameof(DOC205CodeFixProvider)),
+                    diagnostic);
+            }
+
+            return SpecializedTasks.CompletedTask;
+        }
+
+        private static async Task<Document> GetTransformedDocumentAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var xmlNode = (XmlNodeSyntax)root.FindNode(diagnostic.Location.SourceSpan, findInsideTrivia: true, getInnermostNodeForTie: true);
+            var oldStartToken = xmlNode.GetName().LocalName;
+
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var documentedSymbol = semanticModel.GetDeclaredSymbol(xmlNode.FirstAncestorOrSelf<SyntaxNode>(SyntaxNodeExtensionsEx.IsSymbolDeclaration), cancellationToken);
+            var candidateSymbol = GetCandidateSymbol(documentedSymbol);
+            var candidateDocumentation = candidateSymbol.GetDocumentationCommentXml(expandIncludes: false, cancellationToken: cancellationToken);
+
+            var xmlDocumentation = XElement.Parse(candidateDocumentation);
+            var newLineText = Environment.NewLine;
+
+            var content = new List<XmlNodeSyntax>();
+            content.AddRange(xmlDocumentation.Elements().Select(element => XmlSyntaxFactory.Node(newLineText, element)));
+
+            var newStartToken = SyntaxFactory.Identifier(oldStartToken.LeadingTrivia, "autoinheritdoc", oldStartToken.TrailingTrivia);
+            var newXmlNode = xmlNode.ReplaceToken(oldStartToken, newStartToken);
+
+            if (newXmlNode is XmlElementSyntax newXmlElement)
+            {
+                var oldEndToken = newXmlElement.EndTag.Name.LocalName;
+                var newEndToken = SyntaxFactory.Identifier(oldEndToken.LeadingTrivia, "autoinheritdoc", oldEndToken.TrailingTrivia);
+                newXmlNode = newXmlNode.ReplaceToken(oldEndToken, newEndToken);
+            }
+
+            content.Add(XmlSyntaxFactory.NewLine(newLineText));
+            content.Add(newXmlNode);
+
+            return document.WithSyntaxRoot(root.ReplaceNode(xmlNode, content));
+        }
+
+        private static ISymbol GetCandidateSymbol(ISymbol memberSymbol)
+        {
+            if (memberSymbol is IMethodSymbol methodSymbol)
+            {
+                if (methodSymbol.MethodKind == MethodKind.Constructor || methodSymbol.MethodKind == MethodKind.StaticConstructor)
+                {
+                    var baseType = memberSymbol.ContainingType.BaseType;
+                    return baseType.Constructors.Where(c => IsSameSignature(methodSymbol, c)).FirstOrDefault();
+                }
+                else if (!methodSymbol.ExplicitInterfaceImplementations.IsEmpty)
+                {
+                    // prototype(inheritdoc): do we need 'OrDefault'?
+                    return methodSymbol.ExplicitInterfaceImplementations.FirstOrDefault();
+                }
+                else if (methodSymbol.IsOverride)
+                {
+                    return methodSymbol.OverriddenMethod;
+                }
+                else
+                {
+                    // prototype(inheritdoc): check for implicit interface
+                    return null;
+                }
+            }
+            else if (memberSymbol is INamedTypeSymbol typeSymbol)
+            {
+                if (typeSymbol.TypeKind == TypeKind.Class)
+                {
+                    // prototype(inheritdoc): when does base class take precedence over interface?
+                    return typeSymbol.BaseType;
+                }
+                else if (typeSymbol.TypeKind == TypeKind.Interface)
+                {
+                    return typeSymbol.Interfaces.FirstOrDefault();
+                }
+                else
+                {
+                    // This includes structs, enums, and delegates as mentioned in the inheritdoc spec
+                    return null;
+                }
+            }
+
+            return null;
+        }
+
+        private static bool IsSameSignature(IMethodSymbol left, IMethodSymbol right)
+        {
+            if (left.Parameters.Length != right.Parameters.Length)
+            {
+                return false;
+            }
+
+            if (left.IsStatic != right.IsStatic)
+            {
+                return false;
+            }
+
+            if (!left.ReturnType.Equals(right.ReturnType))
+            {
+                return false;
+            }
+
+            for (int i = 0; i < left.Parameters.Length; i++)
+            {
+                if (!left.Parameters[i].Type.Equals(right.Parameters[i].Type))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/DocumentationAnalyzers/DocumentationAnalyzers.Test.CSharp7/PortabilityRules/DOC205CSharp7UnitTests.cs
+++ b/DocumentationAnalyzers/DocumentationAnalyzers.Test.CSharp7/PortabilityRules/DOC205CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT license. See LICENSE in the project root for license information.
+
+namespace DocumentationAnalyzers.Test.CSharp7.PortabilityRules
+{
+    using DocumentationAnalyzers.Test.PortabilityRules;
+
+    public class DOC205CSharp7UnitTests : DOC205UnitTests
+    {
+    }
+}

--- a/DocumentationAnalyzers/DocumentationAnalyzers.Test.CSharp7/PortabilityRules/DOC206CSharp7UnitTests.cs
+++ b/DocumentationAnalyzers/DocumentationAnalyzers.Test.CSharp7/PortabilityRules/DOC206CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT license. See LICENSE in the project root for license information.
+
+namespace DocumentationAnalyzers.Test.CSharp7.PortabilityRules
+{
+    using DocumentationAnalyzers.Test.PortabilityRules;
+
+    public class DOC206CSharp7UnitTests : DOC206UnitTests
+    {
+    }
+}

--- a/DocumentationAnalyzers/DocumentationAnalyzers.Test/PortabilityRules/DOC205UnitTests.cs
+++ b/DocumentationAnalyzers/DocumentationAnalyzers.Test/PortabilityRules/DOC205UnitTests.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT license. See LICENSE in the project root for license information.
+
+namespace DocumentationAnalyzers.Test.PortabilityRules
+{
+    using System.Threading.Tasks;
+    using Xunit;
+    using Verify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixVerifier<DocumentationAnalyzers.PortabilityRules.DOC205InheritDocumentation, DocumentationAnalyzers.PortabilityRules.DOC205CodeFixProvider, Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>;
+
+    public class DOC205UnitTests
+    {
+        [Fact]
+        public async Task TestConvertToAutoinheritdoc1Async()
+        {
+            var testCode = @"
+/// [|<inheritdoc/>|]
+class TestClass : BaseClass
+{
+}
+
+class BaseClass
+{
+}
+";
+            var fixedCode = @"
+/// <autoinheritdoc/>
+class TestClass : BaseClass
+{
+}
+
+class BaseClass
+{
+}
+";
+
+            await Verify.VerifyCodeFixAsync(testCode, fixedCode);
+        }
+
+        [Fact]
+        public async Task TestConvertToAutoinheritdoc2Async()
+        {
+            var testCode = @"
+/// [|<inheritdoc></inheritdoc>|]
+class TestClass : BaseClass
+{
+}
+
+class BaseClass
+{
+}
+";
+            var fixedCode = @"
+/// <autoinheritdoc></autoinheritdoc>
+class TestClass : BaseClass
+{
+}
+
+class BaseClass
+{
+}
+";
+
+            await Verify.VerifyCodeFixAsync(testCode, fixedCode);
+        }
+
+        [Fact]
+        public async Task TestInheritSummaryAsync()
+        {
+            var testCode = @"
+/// [|<inheritdoc/>|]
+class TestClass : BaseClass
+{
+}
+
+/// <summary>
+/// Summary text.
+/// </summary>
+class BaseClass
+{
+}
+";
+            var fixedCode = @"
+/// <summary>
+/// Summary text.
+/// </summary>
+/// <autoinheritdoc/>
+class TestClass : BaseClass
+{
+}
+
+/// <summary>
+/// Summary text.
+/// </summary>
+class BaseClass
+{
+}
+";
+
+            await Verify.VerifyCodeFixAsync(testCode, fixedCode);
+        }
+    }
+}

--- a/DocumentationAnalyzers/DocumentationAnalyzers.Test/PortabilityRules/DOC206UnitTests.cs
+++ b/DocumentationAnalyzers/DocumentationAnalyzers.Test/PortabilityRules/DOC206UnitTests.cs
@@ -1,0 +1,112 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT license. See LICENSE in the project root for license information.
+
+namespace DocumentationAnalyzers.Test.PortabilityRules
+{
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CSharp.Testing;
+    using Microsoft.CodeAnalysis.Testing;
+    using Xunit;
+    using Verify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixVerifier<DocumentationAnalyzers.PortabilityRules.DOC206SynchronizeDocumentation, DocumentationAnalyzers.PortabilityRules.DOC206CodeFixProvider, Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>;
+
+    public class DOC206UnitTests
+    {
+        [Fact]
+        public async Task TestInheritSummaryAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Summary text.
+/// </summary>
+/// <autoinheritdoc/>
+class TestClass : BaseClass
+{
+}
+
+/// <summary>
+/// Summary text.
+/// </summary>
+class BaseClass
+{
+}
+";
+
+            await Verify.VerifyAnalyzerAsync(testCode);
+        }
+
+        [Fact]
+        public async Task TestIncorrectSummaryAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Incorrect summary text.
+/// </summary>
+/// [|<autoinheritdoc/>|]
+class TestClass : BaseClass
+{
+}
+
+/// <summary>
+/// Summary text.
+/// </summary>
+class BaseClass
+{
+}
+";
+            var fixedCode = @"
+/// <summary>
+/// Summary text.
+/// </summary>
+/// <autoinheritdoc/>
+class TestClass : BaseClass
+{
+}
+
+/// <summary>
+/// Summary text.
+/// </summary>
+class BaseClass
+{
+}
+";
+
+            await Verify.VerifyCodeFixAsync(testCode, fixedCode);
+        }
+
+        [Fact]
+        public async Task TestMissingSummaryAsync()
+        {
+            var testCode = @"
+/// [|<autoinheritdoc/>|]
+class TestClass : BaseClass
+{
+}
+
+/// <summary>
+/// Summary text.
+/// </summary>
+class BaseClass
+{
+}
+";
+            var fixedCode = @"
+/// <summary>
+/// Summary text.
+/// </summary>
+/// <autoinheritdoc/>
+class TestClass : BaseClass
+{
+}
+
+/// <summary>
+/// Summary text.
+/// </summary>
+class BaseClass
+{
+}
+";
+
+            await Verify.VerifyCodeFixAsync(testCode, fixedCode);
+        }
+    }
+}

--- a/DocumentationAnalyzers/DocumentationAnalyzers/Helpers/InheritdocHelper.cs
+++ b/DocumentationAnalyzers/DocumentationAnalyzers/Helpers/InheritdocHelper.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT license. See LICENSE in the project root for license information.
+
+namespace DocumentationAnalyzers.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Threading;
+    using System.Xml.Linq;
+    using Microsoft.CodeAnalysis;
+
+    internal static class InheritdocHelper
+    {
+        internal static ISymbol GetCandidateSymbol(ISymbol memberSymbol)
+        {
+            if (memberSymbol is IMethodSymbol methodSymbol)
+            {
+                if (methodSymbol.MethodKind == MethodKind.Constructor || methodSymbol.MethodKind == MethodKind.StaticConstructor)
+                {
+                    var baseType = memberSymbol.ContainingType.BaseType;
+                    return baseType.Constructors.Where(c => IsSameSignature(methodSymbol, c)).FirstOrDefault();
+                }
+                else if (!methodSymbol.ExplicitInterfaceImplementations.IsEmpty)
+                {
+                    // prototype(inheritdoc): do we need 'OrDefault'?
+                    return methodSymbol.ExplicitInterfaceImplementations.FirstOrDefault();
+                }
+                else if (methodSymbol.IsOverride)
+                {
+                    return methodSymbol.OverriddenMethod;
+                }
+                else
+                {
+                    // prototype(inheritdoc): check for implicit interface
+                    return null;
+                }
+            }
+            else if (memberSymbol is INamedTypeSymbol typeSymbol)
+            {
+                if (typeSymbol.TypeKind == TypeKind.Class)
+                {
+                    // prototype(inheritdoc): when does base class take precedence over interface?
+                    return typeSymbol.BaseType;
+                }
+                else if (typeSymbol.TypeKind == TypeKind.Interface)
+                {
+                    return typeSymbol.Interfaces.FirstOrDefault();
+                }
+                else
+                {
+                    // This includes structs, enums, and delegates as mentioned in the inheritdoc spec
+                    return null;
+                }
+            }
+
+            return null;
+        }
+
+        internal static string GetDocumentationCommentXml(ISymbol symbol, CultureInfo preferredCulture, bool expandInheritdoc, bool expandIncludes, CancellationToken cancellationToken)
+        {
+            var result = symbol.GetDocumentationCommentXml(preferredCulture, expandIncludes, cancellationToken);
+            if (expandInheritdoc && !string.IsNullOrEmpty(result))
+            {
+                var element = XElement.Parse(result);
+                var inheritedDocumentation = GetDocumentationCommentXml(GetCandidateSymbol(symbol), preferredCulture, expandInheritdoc: true, expandIncludes: true, cancellationToken);
+                if (element.Elements(XmlCommentHelper.InheritdocXmlTag).Any())
+                {
+                    if (!string.IsNullOrEmpty(inheritedDocumentation))
+                    {
+                        IEnumerable<XObject> content = element.Attributes();
+                        content = content.Concat(XElement.Parse(inheritedDocumentation).Nodes());
+                        content = content.Concat(new[] { new XElement(XmlCommentHelper.AutoinheritdocXmlTag) });
+                        element.ReplaceAll(content);
+                    }
+                    else
+                    {
+                        IEnumerable<XObject> content = element.Attributes();
+                        content = content.Concat(new[] { new XElement(XmlCommentHelper.AutoinheritdocXmlTag) });
+                        element.ReplaceAll(content);
+                    }
+                }
+                else if (element.Elements(XmlCommentHelper.AutoinheritdocXmlTag).Any())
+                {
+                    if (!string.IsNullOrEmpty(inheritedDocumentation))
+                    {
+                        IEnumerable<XObject> content = element.Attributes();
+                        content = content.Concat(XElement.Parse(inheritedDocumentation).Nodes());
+                        content = content.Concat(new[] { new XElement(XmlCommentHelper.AutoinheritdocXmlTag) });
+                        element.ReplaceAll(content);
+                    }
+                    else
+                    {
+                        IEnumerable<XObject> content = element.Attributes();
+                        content = content.Concat(new[] { new XElement(XmlCommentHelper.AutoinheritdocXmlTag) });
+                        element.ReplaceAll(content);
+                    }
+                }
+
+                result = element.ToString();
+            }
+            else if (!string.IsNullOrEmpty(result))
+            {
+                result = XElement.Parse(result).ToString();
+            }
+
+            return result;
+        }
+
+        private static bool IsSameSignature(IMethodSymbol left, IMethodSymbol right)
+        {
+            if (left.Parameters.Length != right.Parameters.Length)
+            {
+                return false;
+            }
+
+            if (left.IsStatic != right.IsStatic)
+            {
+                return false;
+            }
+
+            if (!left.ReturnType.Equals(right.ReturnType))
+            {
+                return false;
+            }
+
+            for (int i = 0; i < left.Parameters.Length; i++)
+            {
+                if (!left.Parameters[i].Type.Equals(right.Parameters[i].Type))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/DocumentationAnalyzers/DocumentationAnalyzers/Helpers/XmlCommentHelper.cs
+++ b/DocumentationAnalyzers/DocumentationAnalyzers/Helpers/XmlCommentHelper.cs
@@ -18,6 +18,7 @@ namespace DocumentationAnalyzers.Helpers
         internal const string SummaryXmlTag = "summary";
         internal const string ContentXmlTag = "content";
         internal const string InheritdocXmlTag = "inheritdoc";
+        internal const string AutoinheritdocXmlTag = "autoinheritdoc";
         internal const string ReturnsXmlTag = "returns";
         internal const string ValueXmlTag = "value";
         internal const string CXmlTag = "c";

--- a/DocumentationAnalyzers/DocumentationAnalyzers/PortabilityRules/DOC205InheritDocumentation.cs
+++ b/DocumentationAnalyzers/DocumentationAnalyzers/PortabilityRules/DOC205InheritDocumentation.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT license. See LICENSE in the project root for license information.
+
+namespace DocumentationAnalyzers.PortabilityRules
+{
+    using System.Collections.Immutable;
+    using DocumentationAnalyzers.Helpers;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    internal class DOC205InheritDocumentation : DiagnosticAnalyzer
+    {
+        /// <summary>
+        /// The ID for diagnostics produced by the <see cref="DOC205InheritDocumentation"/> analyzer.
+        /// </summary>
+        public const string DiagnosticId = "DOC205";
+        private const string HelpLink = "https://github.com/DotNetAnalyzers/DocumentationAnalyzers/blob/master/docs/DOC205.md";
+
+        private static readonly LocalizableString Title = new LocalizableResourceString(nameof(PortabilityResources.DOC205Title), PortabilityResources.ResourceManager, typeof(PortabilityResources));
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(PortabilityResources.DOC205MessageFormat), PortabilityResources.ResourceManager, typeof(PortabilityResources));
+        private static readonly LocalizableString Description = new LocalizableResourceString(nameof(PortabilityResources.DOC205Description), PortabilityResources.ResourceManager, typeof(PortabilityResources));
+
+        private static readonly DiagnosticDescriptor Descriptor =
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.PortabilityRules, DiagnosticSeverity.Info, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
+
+        /// <inheritdoc/>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
+            = ImmutableArray.Create(Descriptor);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterSyntaxNodeAction(HandleXmlNodeSyntax, SyntaxKind.XmlElement, SyntaxKind.XmlEmptyElement);
+        }
+
+        private static void HandleXmlNodeSyntax(SyntaxNodeAnalysisContext context)
+        {
+            var xmlNodeSyntax = (XmlNodeSyntax)context.Node;
+            var name = xmlNodeSyntax.GetName();
+            if (name.Prefix != null)
+            {
+                return;
+            }
+
+            if (name.LocalName.ValueText != XmlCommentHelper.InheritdocXmlTag)
+            {
+                return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, context.Node.GetLocation()));
+        }
+    }
+}

--- a/DocumentationAnalyzers/DocumentationAnalyzers/PortabilityRules/DOC205InheritDocumentation.cs
+++ b/DocumentationAnalyzers/DocumentationAnalyzers/PortabilityRules/DOC205InheritDocumentation.cs
@@ -24,7 +24,7 @@ namespace DocumentationAnalyzers.PortabilityRules
         private static readonly LocalizableString Description = new LocalizableResourceString(nameof(PortabilityResources.DOC205Description), PortabilityResources.ResourceManager, typeof(PortabilityResources));
 
         private static readonly DiagnosticDescriptor Descriptor =
-            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.PortabilityRules, DiagnosticSeverity.Info, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.PortabilityRules, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
 
         /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }

--- a/DocumentationAnalyzers/DocumentationAnalyzers/PortabilityRules/DOC206SynchronizeDocumentation.cs
+++ b/DocumentationAnalyzers/DocumentationAnalyzers/PortabilityRules/DOC206SynchronizeDocumentation.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT license. See LICENSE in the project root for license information.
+
+namespace DocumentationAnalyzers.PortabilityRules
+{
+    using System.Collections.Immutable;
+    using System.Globalization;
+    using DocumentationAnalyzers.Helpers;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    internal class DOC206SynchronizeDocumentation : DiagnosticAnalyzer
+    {
+        /// <summary>
+        /// The ID for diagnostics produced by the <see cref="DOC206SynchronizeDocumentation"/> analyzer.
+        /// </summary>
+        public const string DiagnosticId = "DOC206";
+        private const string HelpLink = "https://github.com/DotNetAnalyzers/DocumentationAnalyzers/blob/master/docs/DOC206.md";
+
+        private static readonly LocalizableString Title = new LocalizableResourceString(nameof(PortabilityResources.DOC206Title), PortabilityResources.ResourceManager, typeof(PortabilityResources));
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(PortabilityResources.DOC206MessageFormat), PortabilityResources.ResourceManager, typeof(PortabilityResources));
+        private static readonly LocalizableString Description = new LocalizableResourceString(nameof(PortabilityResources.DOC206Description), PortabilityResources.ResourceManager, typeof(PortabilityResources));
+
+        private static readonly DiagnosticDescriptor Descriptor =
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.PortabilityRules, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
+
+        /// <inheritdoc/>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
+            = ImmutableArray.Create(Descriptor);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterSyntaxNodeAction(HandleXmlNodeSyntax, SyntaxKind.XmlElement, SyntaxKind.XmlEmptyElement);
+        }
+
+        private static void HandleXmlNodeSyntax(SyntaxNodeAnalysisContext context)
+        {
+            var xmlNode = (XmlNodeSyntax)context.Node;
+            var name = xmlNode.GetName();
+            if (name.Prefix != null)
+            {
+                return;
+            }
+
+            if (name.LocalName.ValueText != XmlCommentHelper.AutoinheritdocXmlTag)
+            {
+                return;
+            }
+
+            var documentedSymbol = context.SemanticModel.GetDeclaredSymbol(xmlNode.FirstAncestorOrSelf<SyntaxNode>(SyntaxNodeExtensionsEx.IsSymbolDeclaration), context.CancellationToken);
+            var currentDocumentation = InheritdocHelper.GetDocumentationCommentXml(documentedSymbol, CultureInfo.CurrentCulture, expandInheritdoc: false, expandIncludes: false, context.CancellationToken);
+            var expectedDocumentation = InheritdocHelper.GetDocumentationCommentXml(documentedSymbol, CultureInfo.CurrentCulture, expandInheritdoc: true, expandIncludes: false, context.CancellationToken);
+            if (currentDocumentation == expectedDocumentation)
+            {
+                return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, context.Node.GetLocation()));
+        }
+    }
+}

--- a/DocumentationAnalyzers/DocumentationAnalyzers/PortabilityRules/PortabilityResources.Designer.cs
+++ b/DocumentationAnalyzers/DocumentationAnalyzers/PortabilityRules/PortabilityResources.Designer.cs
@@ -242,6 +242,42 @@ namespace DocumentationAnalyzers.PortabilityRules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Inherit documentation.
+        /// </summary>
+        internal static string DOC205CodeFix {
+            get {
+                return ResourceManager.GetString("DOC205CodeFix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Inherit documentation.
+        /// </summary>
+        internal static string DOC205Description {
+            get {
+                return ResourceManager.GetString("DOC205Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Inherit documentation.
+        /// </summary>
+        internal static string DOC205MessageFormat {
+            get {
+                return ResourceManager.GetString("DOC205MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Inherit documentation.
+        /// </summary>
+        internal static string DOC205Title {
+            get {
+                return ResourceManager.GetString("DOC205Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;langword&apos; attribute value should be a language keyword.
         /// </summary>
         internal static string DOC207Description {

--- a/DocumentationAnalyzers/DocumentationAnalyzers/PortabilityRules/PortabilityResources.Designer.cs
+++ b/DocumentationAnalyzers/DocumentationAnalyzers/PortabilityRules/PortabilityResources.Designer.cs
@@ -278,6 +278,42 @@ namespace DocumentationAnalyzers.PortabilityRules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Synchronize documentation.
+        /// </summary>
+        internal static string DOC206CodeFix {
+            get {
+                return ResourceManager.GetString("DOC206CodeFix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Synchronize documentation.
+        /// </summary>
+        internal static string DOC206Description {
+            get {
+                return ResourceManager.GetString("DOC206Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Synchronize documentation.
+        /// </summary>
+        internal static string DOC206MessageFormat {
+            get {
+                return ResourceManager.GetString("DOC206MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Synchronize documentation.
+        /// </summary>
+        internal static string DOC206Title {
+            get {
+                return ResourceManager.GetString("DOC206Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;langword&apos; attribute value should be a language keyword.
         /// </summary>
         internal static string DOC207Description {

--- a/DocumentationAnalyzers/DocumentationAnalyzers/PortabilityRules/PortabilityResources.resx
+++ b/DocumentationAnalyzers/DocumentationAnalyzers/PortabilityRules/PortabilityResources.resx
@@ -177,6 +177,18 @@
   <data name="DOC204Title" xml:space="preserve">
     <value>Use inline elements correctly</value>
   </data>
+  <data name="DOC205CodeFix" xml:space="preserve">
+    <value>Inherit documentation</value>
+  </data>
+  <data name="DOC205Description" xml:space="preserve">
+    <value>Inherit documentation</value>
+  </data>
+  <data name="DOC205MessageFormat" xml:space="preserve">
+    <value>Inherit documentation</value>
+  </data>
+  <data name="DOC205Title" xml:space="preserve">
+    <value>Inherit documentation</value>
+  </data>
   <data name="DOC207Description" xml:space="preserve">
     <value>'langword' attribute value should be a language keyword</value>
   </data>

--- a/DocumentationAnalyzers/DocumentationAnalyzers/PortabilityRules/PortabilityResources.resx
+++ b/DocumentationAnalyzers/DocumentationAnalyzers/PortabilityRules/PortabilityResources.resx
@@ -189,6 +189,18 @@
   <data name="DOC205Title" xml:space="preserve">
     <value>Inherit documentation</value>
   </data>
+  <data name="DOC206CodeFix" xml:space="preserve">
+    <value>Synchronize documentation</value>
+  </data>
+  <data name="DOC206Description" xml:space="preserve">
+    <value>Synchronize documentation</value>
+  </data>
+  <data name="DOC206MessageFormat" xml:space="preserve">
+    <value>Synchronize documentation</value>
+  </data>
+  <data name="DOC206Title" xml:space="preserve">
+    <value>Synchronize documentation</value>
+  </data>
   <data name="DOC207Description" xml:space="preserve">
     <value>'langword' attribute value should be a language keyword</value>
   </data>

--- a/docs/DOC205.md
+++ b/docs/DOC205.md
@@ -1,0 +1,37 @@
+﻿# DOC205
+
+<table>
+<tr>
+  <td>TypeName</td>
+  <td>DOC205InheritDocumentation</td>
+</tr>
+<tr>
+  <td>CheckId</td>
+  <td>DOC205</td>
+</tr>
+<tr>
+  <td>Category</td>
+  <td>Portability Rules</td>
+</tr>
+</table>
+
+## Cause
+
+The documentation contains an `<inheritdoc>` element.
+
+## Rule description
+
+XML documentation comments do not currently recognize the `<inheritdoc/>` element. For maximum portability,
+documentation should be directly included for each documented element.
+
+💡 The code fix for DOC205 works with [DOC206 (Synchronize Documentation)](DOC206.md) to ensure documentation remains
+updated and correct over time. If a future release of the compiler natively supports `<inheritdoc/>`
+(dotnet/csharplang#313), the `<autoinheritdoc/>` syntax will support seamless migration to the new compiler features.
+
+## How to fix violations
+
+*TODO*
+
+## How to suppress violations
+
+*TODO*

--- a/docs/DOC206.md
+++ b/docs/DOC206.md
@@ -1,0 +1,38 @@
+﻿# DOC206
+
+<table>
+<tr>
+  <td>TypeName</td>
+  <td>DOC206SynchronizeDocumentation</td>
+</tr>
+<tr>
+  <td>CheckId</td>
+  <td>DOC206</td>
+</tr>
+<tr>
+  <td>Category</td>
+  <td>Portability Rules</td>
+</tr>
+</table>
+
+## Cause
+
+The documentation contains an `<autoinheritdoc>` element, but the included documentation is out-of-date with respect to
+the source documentation.
+
+## Rule description
+
+XML documentation comments do not currently recognize the `<inheritdoc/>` element. For maximum portability,
+documentation should be directly included for each documented element.
+
+💡 The code fix for [DOC205 (Inherit Documentation)](DOC205.md) works with DOC206 to ensure documentation remains
+updated and correct over time. If a future release of the compiler natively supports `<inheritdoc/>`
+(dotnet/csharplang#313), the `<autoinheritdoc/>` syntax will support seamless migration to the new compiler features.
+
+## How to fix violations
+
+*TODO*
+
+## How to suppress violations
+
+*TODO*

--- a/docs/DOC206.md
+++ b/docs/DOC206.md
@@ -17,8 +17,8 @@
 
 ## Cause
 
-The documentation contains an `<autoinheritdoc>` element, but the included documentation is out-of-date with respect to
-the source documentation.
+The documentation contains an `<autoinheritdoc>` element, but the included documentation is out-of-date with respect
+to the source documentation.
 
 ## Rule description
 

--- a/docs/PortabilityRules.md
+++ b/docs/PortabilityRules.md
@@ -9,5 +9,7 @@ Identifier | Name | Description
 [DOC202](DOC202.md) | UseSectionElementsCorrectly | The documentation contains a section element where a block or inline element was expected.
 [DOC203](DOC203.md) | UseBlockElementsCorrectly | The documentation contains a block element where a section or inline element was expected.
 [DOC204](DOC204.md) | UseInlineElementsCorrectly | The documentation contains an inline element where a section or block element was expected.
+[DOC205](DOC205.md) | InheritDocumentation | The documentation contains an `<inheritdoc>` element.
+[DOC206](DOC206.md) | SynchronizeDocumentation | The documentation contains an `<autoinheritdoc>` element, but the included documentation is out-of-date with respect to the source documentation.
 [DOC207](DOC207.md) | UseSeeLangwordCorrectly | The documentation contains a `<see langword="..."/>` element with an unrecognized keyword.
 [DOC209](DOC209.md) | UseSeeHrefCorrectly | The documentation contains a `<see href="..."/>` element with an unrecognized URI.


### PR DESCRIPTION
Quite a bit of work remaining here to handle edge cases:

* General inheritance implementation
  * [ ] Handle `include` elements: translate paths when a relative path will work, otherwise expand the element.
  * [ ] Handle recursive `inheritdoc` elements
  * [ ] Define behavior when a library contains `<inheritdoc>` elements in its documentation
* `inheritdoc` (DOC205)
  * [ ] Handle overridden root elements
  * [ ] Support nesting `<inheritdoc>` within a root element, e.g. within a `<summary>` element
  * [ ] Support the `path`/`select` attributes
  * [ ] Support the `cref` attribute
* `autoinheritdoc` (DOC206)
  * [ ] Exclusions for overridden root elements, which may be built on `path`/`select` support
  * [ ] Normalization of text
  * [ ] Define behavior for cases where included documentation is not available
  * [ ] Support the `cref` attribute
  * [ ] Support placement as a nested element

Closes #16