### PR TITLE
Install and enable FormattingAnalyzer

### DIFF
--- a/DocumentationAnalyzers/Directory.Build.props
+++ b/DocumentationAnalyzers/Directory.Build.props
@@ -45,6 +45,7 @@
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta009" PrivateAssets="all" />
     <PackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="2.11.0-beta2-63603-03" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DocumentationAnalyzers/DocumentationAnalyzers.ruleset
+++ b/DocumentationAnalyzers/DocumentationAnalyzers.ruleset
@@ -71,6 +71,9 @@
     <Rule Id="RS1022" Action="None" />
     <!-- https://github.com/dotnet/roslyn-analyzers/issues/1803 -->
   </Rules>
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.CodeStyle" RuleNamespace="Microsoft.CodeAnalysis.CSharp.CodeStyle">
+    <Rule Id="IDE0055" Action="Warning" />
+  </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
     <Rule Id="IDE0003" Action="None" />
   </Rules>


### PR DESCRIPTION
Enabling FormattingAnalyzer involves three steps:

1. Make sure the Roslyn MyGet feed is available to NuGet. This step was already complete for this repository, but other users can add the following to get it:

    https://github.com/DotNetAnalyzers/DocumentationAnalyzers/blob/cf433d105027cb0ca3f9a258b30116feee8acc73/NuGet.config#L4

2. Add a `<PackageReference>` for **Microsoft.CodeAnalysis.CSharp.CodeStyle** and/or **Microsoft.CodeAnalysis.VisualBasic.CodeStyle** (only the former is required for this repository)

3. Use a rule set file to enable IDE0055, the diagnostic reported by FormattingAnalyzer