### PR TITLE
Update "LICENSE" so that it's recognized as MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-﻿The MIT License (MIT)
+MIT License
 
 Copyright (c) Tunnel Vision Laboratories, LLC
 


### PR DESCRIPTION
This PR replicates DotNetAnalyzers/StyleCopAnalyzers#3182.

License text is from: https://choosealicense.com/licenses/mit/