### PR TITLE
Fix missing words in docs and descriptions for DOC104-107

### DIFF
--- a/docs/DOC104.md
+++ b/docs/DOC104.md
@@ -17,13 +17,13 @@
 
 ## Cause
 
-The contains a language keyword reference using `<c>keyword</c>` that can be converted to the preferred form
-`<see langword="keyword"/>`.
+The documentation contains a language keyword reference using `<c>keyword</c>` that can be converted to the preferred
+form `<see langword="keyword"/>`.
 
 ## Rule description
 
-A violation of this rule occurs when documentation a language keyword reference written in inline code that can be
-written in a preferred form using `see langword`.
+A violation of this rule occurs when documentation contains a language keyword reference written in inline code that can
+be written in a preferred form using `see langword`.
 
 ```csharp
 /// <summary>

--- a/docs/DOC105.md
+++ b/docs/DOC105.md
@@ -17,7 +17,7 @@
 
 ## Cause
 
-The contains a parameter reference using `<c>name</c>` that can be converted to the preferred form
+The documentation contains a parameter reference using `<c>name</c>` that can be converted to the preferred form
 `<paramref name="name"/>`.
 
 ## Rule description

--- a/docs/DOC106.md
+++ b/docs/DOC106.md
@@ -17,7 +17,7 @@
 
 ## Cause
 
-The contains a type parameter reference using `<c>T</c>` that can be converted to the preferred form
+The documentation contains a type parameter reference using `<c>T</c>` that can be converted to the preferred form
 `<typeparamref name="T"/>`.
 
 ## Rule description

--- a/docs/DOC107.md
+++ b/docs/DOC107.md
@@ -17,7 +17,7 @@
 
 ## Cause
 
-The contains a code element reference using `<c>name</c>` that can be converted to the preferred form
+The documentation contains a code element reference using `<c>name</c>` that can be converted to the preferred form
 `<see cref="name"/>`.
 
 ## Rule description

--- a/docs/StyleRules.md
+++ b/docs/StyleRules.md
@@ -8,8 +8,8 @@ Identifier | Name | Description
 [DOC101](DOC101.md) | UseChildBlocksConsistently | The documentation for the element contains some text which is wrapped in block-level elements, and other text which is written inline.
 [DOC102](DOC102.md) | UseChildBlocksConsistentlyAcrossElementsOfTheSameKind | The documentation for the element contains inline text, but the documentation for a sibling element of the same kind uses block-level elements.
 [DOC103](DOC103.md) | UseUnicodeCharacters | The documentation contains an unnecessary or unrecognized HTML character entity.
-[DOC104](DOC104.md) | UseSeeLangword | The contains a language keyword reference using `<c>keyword</c>` that can be converted to the preferred form `<see langword="keyword"/>`.
-[DOC105](DOC105.md) | UseParamref | The contains a parameter reference using `<c>name</c>` that can be converted to the preferred form `<paramref name="name"/>`.
-[DOC106](DOC106.md) | UseTypeparamref | The contains a type parameter reference using `<c>T</c>` that can be converted to the preferred form `<typeparamref name="T"/>`.
-[DOC107](DOC107.md) | UseSeeCref | The contains a code element reference using `<c>name</c>` that can be converted to the preferred form `<see cref="name"/>`.
+[DOC104](DOC104.md) | UseSeeLangword | The documentation contains a language keyword reference using `<c>keyword</c>` that can be converted to the preferred form `<see langword="keyword"/>`.
+[DOC105](DOC105.md) | UseParamref | The documentation contains a parameter reference using `<c>name</c>` that can be converted to the preferred form `<paramref name="name"/>`.
+[DOC106](DOC106.md) | UseTypeparamref | The documentation contains a type parameter reference using `<c>T</c>` that can be converted to the preferred form `<typeparamref name="T"/>`.
+[DOC107](DOC107.md) | UseSeeCref | The documentation contains a code element reference using `<c>name</c>` that can be converted to the preferred form `<see cref="name"/>`.
 [DOC108](DOC108.md) | AvoidEmptyParagraphs | The documentation contains an empty paragraph element (`<para/>` or `<p/>`) used as a paragraph separator.


### PR DESCRIPTION
Should fix issue #86 